### PR TITLE
Create toolbox image for AWS #13

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,6 +17,15 @@ It also could be triggered manually and set a custom tag. In this case, the `cus
 
 As a result docker image with the next tags will be pushed to `ghcr.io` repository: `YYYYMMDD-HHmmss-base`, `YYYYMMDD-HHmmss`, `base`, `latest`.
 
+## AWS toolbox workflow [toolbox-aws.yaml]
+
+This workflow is used to trigger the build and push of the aws toolbox docker image.
+It triggers by creating a git tag `aws`.
+
+It also could be triggered manually and set a custom tag. In this case, the `custom-aws-` prefix will always be added to a custom tag value (ex. input: `mytag`, result tag: `custom-aws-mytag`)
+
+As a result docker image with the next tags will be pushed to `ghcr.io` repository: `YYYYMMDD-HHmmss-aws`, `aws`.
+
 ## GCP toolbox workflow [toolbox-gcp.yaml]
 
 This workflow is used to trigger the build and push of the gcp toolbox docker image.

--- a/.github/workflows/toolbox-aws.yaml
+++ b/.github/workflows/toolbox-aws.yaml
@@ -1,0 +1,84 @@
+name: 'Build and Push - AWS Toolbox'
+
+on:
+  push:
+    tags:
+    - 'aws'
+  workflow_dispatch:
+    inputs:
+      customTag:
+        description: 'Custom base image tag. Empty value triggers release build'
+        required: false
+        default: ''
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      -
+        name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: 'Set up Docker Buildx'
+        uses: 'docker/setup-buildx-action@v2'
+        with:
+          platforms: linux/amd64
+
+      -
+        id: 'versions'
+        name: 'Collect versions info'
+        run: |
+          echo "DOCKER_IMAGE_TAG=$(date +"%Y%m%d-%H%M%S")" >> $GITHUB_ENV
+
+      -
+        name: Image meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          flavor: |
+            latest=false
+          images: |
+            ghcr.io/epam/hub-toolbox
+          tags: |
+            type=raw,value=${{ env.DOCKER_IMAGE_TAG }},enable=${{ inputs.customTag == '' }},suffix=-aws
+            type=raw,value=aws,enable=${{ inputs.customTag == '' }}
+            type=raw,value=${{ inputs.customTag }},enable=${{ inputs.customTag != '' }},prefix=custom-aws-
+
+      - name: 'Build and push'
+        uses: "docker/build-push-action@v3"
+        with:
+          context: ./aws
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      -
+        name: 'Tag release'
+        if: ${{ inputs.customTag == '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USERNAME: ${{ github.event.head_commit.author.name || github.actor }}
+          USEREMAIL: ${{ github.event.head_commit.author.email || format('{0}@users.noreply.github.com', github.actor) }}
+        run: |
+          echo "Setup git"
+          git config user.name "$USERNAME"
+          git config user.email "$USEREMAIL"
+          gh auth setup-git
+
+          echo "Create git tag and push it"
+          TAG="${{ steps.meta.outputs.version }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"

--- a/.github/workflows/toolbox-base.yaml
+++ b/.github/workflows/toolbox-base.yaml
@@ -116,12 +116,17 @@ jobs:
           echo "Create git tag and push it"
           TAG="${{ steps.meta.outputs.version }}"
           git tag -a "$TAG" -m "Release $TAG"
+          git tag -a "aws" -m "Base Toolbox release - $TAG" --force
           git tag -a "gcp" -m "Base Toolbox release - $TAG" --force
           git tag -a "azure" -m "Base Toolbox release - $TAG" --force
           # Do not use --tags because `base` is also tag
           git push origin "$TAG"
+          git push origin "aws" --force
           git push origin "gcp" --force
           git push origin "azure" --force
+
+          echo "Start workflow for toolbox-aws"
+          gh workflow run toolbox-aws.yaml
 
           echo "Start workflow for toolbox-azure"
           gh workflow run toolbox-azure.yaml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ The image contains all the tools installed and configured that are required by t
 
 ## Toolbox versions
 
-There are several versions of the image: [`base`](/base/README.md), [`gcp`](/gcp/README.md), [`azure`](/azure/README.md).
+There are several versions of the image: [`base`](/base/README.md), [`aws`](/aws/README.md), [`gcp`](/gcp/README.md), [`azure`](/azure/README.md).
 
 [Hub CTL]: https://github.com/epam/hubctl

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -12,25 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10-alpine3.17 as builder
+FROM python:3.11-alpine3.18 as builder
 
 # Install deps
-RUN apk update && apk upgrade && \
-    apk add --no-cache \
-        git \
-        unzip \
-        groff \
-        build-base \
-        libffi-dev \
-        cmake
+RUN apk update && apk --no-cache --prune upgrade \
+    && apk --no-cache add \
+        git=2.40.1-r0 \
+        unzip=6.0-r14 \
+        groff=1.22.4-r4 \
+        build-base=0.5-r3 \
+        libffi-dev=3.4.4-r2 \
+        cmake=3.26.5-r0 \
+        sqlite-dev=3.41.2-r2
 RUN rm -rf /var/cache/apk/* /tmp/*
 
-RUN mkdir -p /opt/src/aws-cli
-WORKDIR /opt/src/aws-cli
+WORKDIR /opt/src
 
 # Install AWS CLI
 ARG AWS_CLI_VERSION="2.13.14"
-RUN git clone --single-branch --depth 1 -b "${AWS_CLI_VERSION}" https://github.com/aws/aws-cli.git .
+RUN git clone --single-branch --depth 1 -b "${AWS_CLI_VERSION}" https://github.com/aws/aws-cli.git
+WORKDIR /opt/src/aws-cli
 RUN ./configure --with-install-type=portable-exe --with-download-deps
 RUN make
 RUN make install

--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2023 EPAM Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.10-alpine3.17 as builder
+
+# Install deps
+RUN apk update && apk upgrade && \
+    apk add --no-cache \
+        git \
+        unzip \
+        groff \
+        build-base \
+        libffi-dev \
+        cmake
+RUN rm -rf /var/cache/apk/* /tmp/*
+
+RUN mkdir -p /opt/src/aws-cli
+WORKDIR /opt/src/aws-cli
+
+# Install AWS CLI
+ARG AWS_CLI_VERSION="2.13.14"
+RUN git clone --single-branch --depth 1 -b "${AWS_CLI_VERSION}" https://github.com/aws/aws-cli.git .
+RUN ./configure --with-install-type=portable-exe --with-download-deps
+RUN make
+RUN make install
+
+# Clean up
+RUN rm -rf \
+    /usr/local/lib/aws-cli/aws_completer \
+    /usr/local/lib/aws-cli/awscli/data/ac.index \
+    /usr/local/lib/aws-cli/awscli/examples
+RUN find /usr/local/lib/aws-cli/awscli/data -name completions-1*.json -delete
+RUN find /usr/local/lib/aws-cli/awscli/botocore/data -name examples-1.json -delete
+RUN (cd /usr/local/lib/aws-cli; for a in *.so*; do test -f /lib/$a && rm $a; done)
+
+# AWS toolbox
+FROM ghcr.io/epam/hub-toolbox:base
+
+LABEL org.opencontainers.image.url="https://github.com/epam/hub-toolbox"
+LABEL org.opencontainers.image.source="https://github.com/epam/hub-toolbox.git"
+LABEL org.opencontainers.image.authors="Antons Kranga <antons_kranga@epam.com>, Viktors Oginskis <viktors_oginskis@epam.com>, Igor Lysak <igor_lysak@epam.com>"
+LABEL org.opencontainers.image.description="AWS Toolbox is a Docker image that is used to perform provisioning operations on a Hub CTL stack, such as deploy and undeploy in Amazon Web Services."
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=builder /usr/local/lib/aws-cli/ /usr/local/lib/aws-cli/
+
+RUN ln -s /usr/local/lib/aws-cli/aws /usr/local/bin/aws

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2023 EPAM Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.DEFAULT_GOAL := build
+
+IMAGE         ?= ghcr.io/epam/hub-toolbox
+IMAGE_VERSION ?= $(shell git rev-parse HEAD | cut -c-7)-aws
+
+docker ?= docker
+
+DOCKER_BUILD_OPTS := --platform="linux/amd64"
+
+build:
+	$(docker) buildx build \
+		$(DOCKER_BUILD_OPTS) \
+		--tag $(IMAGE):$(IMAGE_VERSION) \
+		--tag $(IMAGE):aws .;
+.PHONY: build
+
+push:
+	$(docker) push $(IMAGE):$(IMAGE_VERSION)
+.PHONY: push
+
+run:
+	$(docker) run --rm -it $(IMAGE):aws
+.PHONY: run
+

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,32 @@
+# AWS Toolbox
+
+This toolbox image is used to automate operations with Hub CTL in Amazon Web Services cloud provider.
+
+## Tools included
+
+* Same as in [`base`](../base/README.md)
+* [AWS Command Line Interface](https://aws.amazon.com/cli/)
+
+## Development
+
+The image release process is done with help of Github Actions workflow which is trigged by creating of a git tag `aws`.
+
+To help with local development there is a `Makefile` with simple goals.
+
+### Build image
+
+```bash
+make build
+```
+
+### Run image
+
+```bash
+make run
+```
+
+### Push image
+
+```bash
+make push
+```


### PR DESCRIPTION
A new toolbox image for AWS. AWS CLI is installed from the source because of the support glibc on Alpine 3.17 and to reduce image size.